### PR TITLE
Signal transduction profile graph

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "@angular/cli": "1.3.2",
     "@angular/compiler-cli": "^4.2.4",
     "@angular/language-service": "^4.2.4",
+    "@ngtools/webpack": "^1.10.2",
     "@types/file-saver": "^1.3.0",
     "@types/jasmine": "~2.5.53",
     "@types/jasminewd2": "~2.0.2",

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -1,14 +1,14 @@
 import { NgModule } from '@angular/core';
 import { HttpModule } from '@angular/http';
-import { 
-  MatButtonModule, 
-  MatIconModule, 
-  MatInputModule, 
-  MatProgressSpinnerModule, 
-  MatTableModule, 
-  MatPaginatorModule, 
-  MatCardModule, 
-  MatCheckboxModule, 
+import {
+  MatButtonModule,
+  MatIconModule,
+  MatInputModule,
+  MatProgressSpinnerModule,
+  MatTableModule,
+  MatPaginatorModule,
+  MatCardModule,
+  MatCheckboxModule,
   MatExpansionModule,
   MatToolbarModule,
   MatGridListModule,
@@ -55,12 +55,13 @@ import { ShopCartGenesComponent } from './shop-cart/shop-cart.genes.component';
 import { ShopCartGenomesComponent } from './shop-cart/shop-cart.genomes.component';
 import { ShopCartGenesList } from './shop-cart/shop-cart.genes.list.component';
 import { ShopCartGenomesList } from './shop-cart/shop-cart.genomes.list.component';
-import { MistEffects } from './core/common/mist-effects'; 
+import { MistEffects } from './core/common/mist-effects';
 import { CartChangedService } from './shop-cart/cart-changed.service';
 import { ScopeService } from './core/components/main-menu/scope.service';
 import { GenesScopeComponent } from './genes/scope/genes-scope.component';
 import { GenesScopeListComponent } from './genes/scope/genes-scope-list.component';
-
+import { GoogleCharts } from './core/services/google-charts.service';
+import { StProfileComponent } from './core/components/st-profile/st-profile.component';
 
 @NgModule({
   bootstrap: [AppComponent],
@@ -88,7 +89,8 @@ import { GenesScopeListComponent } from './genes/scope/genes-scope-list.componen
     ShopCartGenesList,
     ShopCartGenomesList,
     GenesScopeComponent,
-    GenesScopeListComponent
+    GenesScopeListComponent,
+    StProfileComponent,
   ],
   imports: [
     AppRoutingModule,
@@ -116,7 +118,7 @@ import { GenesScopeListComponent } from './genes/scope/genes-scope-list.componen
     McBreadcrumbsModule.forRoot()
   ],
   providers: [
-    MistApi, D3Service, GenomeResolver, GeneResolver, CartChangedService, ScopeService
-  ]
+    MistApi, D3Service, GenomeResolver, GeneResolver, CartChangedService, ScopeService, GoogleCharts,
+  ],
 })
 export class AppModule { }

--- a/src/app/core/components/st-profile/st-profile.component.ts
+++ b/src/app/core/components/st-profile/st-profile.component.ts
@@ -1,0 +1,124 @@
+import { Component, ElementRef, Input, OnInit } from '@angular/core';
+import { zip } from 'rxjs/observable/zip';
+
+import { GoogleCharts } from '../../services/google-charts.service';
+import { MistApi, SignalProfileCount } from '../../services/mist-api.service';
+
+const ucFirst = (value) => value[0].toUpperCase() + value.substr(1);
+
+const COLORS_BY_KIND = {
+  chemotaxis: '#ef5b5b',
+  ecf: '#5f455b',
+  input: '#ffba49',
+  output: '#20a39e',
+  receiver: '#0075f2',
+  transmitter: '#a5907e',
+  unknown: '#a4a9ad',
+};
+
+// We increase the max axis value by this amount to improve the graph appearance
+// with some "headroom" above the tallest bar.
+const AXIS_COUNT_EXTRA = 5;
+
+@Component({
+  selector: 'mist-st-profile',
+  styleUrls: ['./st-profile.scss'],
+  templateUrl: './st-profile.pug',
+})
+export class StProfileComponent implements OnInit {
+  @Input()
+  genomeVersion: number;
+
+  legendHidden = true;
+  height = 500;
+  width = 500;
+
+  private options = {
+    chartArea: {
+      height: '60%',
+      left: '10%',
+      top: '8%',
+      width: '85%',
+    },
+    hAxis: {
+      slantedText: true,
+      slantedTextAngle: 60,
+    },
+    height: this.height,
+    legend: {
+      position: 'none',
+    },
+    title: 'Signal transduction profile',
+    titleTextStyle: {
+      fontSize: 16,
+    },
+    vAxis: {
+      format: 'short',
+      viewWindow: {
+        // This will be changed dynamically after the profile is loaded
+        max: 0,
+        min: 0,
+      },
+      viewWindowMode: 'explicit',
+    },
+    width: this.width,
+  };
+
+  private chartElement: HTMLElement;
+
+  constructor(
+    private mistApi: MistApi,
+    private googleCharts: GoogleCharts,
+    private element: ElementRef,
+  ) {}
+
+  ngOnInit() {
+    this.chartElement = this.element.nativeElement.querySelector('.chart');
+    this.fetchProfileDataAndRenderChart().subscribe();
+  }
+
+  private fetchProfileDataAndRenderChart() {
+    return zip(
+      this.mistApi.fetchStProfileData(this.genomeVersion),
+      this.googleCharts.loaded(),
+    )
+      .take(1)
+      .do(([profile]: [SignalProfileCount[], boolean]) => {
+        const dataTable = this.createDataTable();
+        dataTable.addRows(this.createDataRowsForProfile(profile));
+
+        const chart = new (<any>window).google.visualization.ColumnChart(this.chartElement);
+        (<any>window).google.visualization.events.addListener(chart, 'ready', () => {
+          this.legendHidden = false;
+        });
+        chart.draw(dataTable, this.options);
+      });
+  }
+
+  private createDataTable() {
+    const table = new (<any>window).google.visualization.DataTable();
+    table.addColumn('string', 'Function');
+    table.addColumn('number', 'Domains');
+    table.addColumn({type: 'string', role: 'style'});
+    return table;
+  }
+
+  private createDataRowsForProfile(profile) {
+    const maxNumDomains = this.getMaxNumDomains(profile);
+    this.setAxisMax(maxNumDomains + AXIS_COUNT_EXTRA);
+
+    return profile.map((row) => [
+      row.function === 'ecf' ? 'ECF' : ucFirst(row.function),
+      row.numDomains,
+      COLORS_BY_KIND[row.kind],
+    ]);
+  }
+
+  private getMaxNumDomains(profile: SignalProfileCount[]): number {
+    return profile.reduce((acc, next) => Math.max(acc, next.numDomains), 0);
+  }
+
+  private setAxisMax(max: number) {
+    this.options.vAxis.viewWindow.max = max;
+  }
+}

--- a/src/app/core/components/st-profile/st-profile.pug
+++ b/src/app/core/components/st-profile/st-profile.pug
@@ -1,0 +1,11 @@
+.chart-container(
+    [ngStyle]="{'width.px': width, 'height.px': height}"
+  )
+  .chart
+  .legend([class.hide]="legendHidden")
+    .item.input
+      .box
+      .label Inputs
+    .item.output
+      .box
+      .label Outputs

--- a/src/app/core/components/st-profile/st-profile.scss
+++ b/src/app/core/components/st-profile/st-profile.scss
@@ -1,0 +1,46 @@
+.chart-container {
+  position: relative;
+}
+
+.hide {
+  display: none;
+}
+
+.legend {
+  position: absolute;
+  top: 10px;
+  right: 10px;
+  z-index: 1;
+  font-family: Arial;
+  font-size: 13px;
+  border: 1px solid #eee;
+  padding: 5px;
+  background-color: #fff;
+}
+
+.item {
+  height: 15px;
+}
+
+.item + .item {
+  margin-top: 5px;
+}
+
+.item > div {
+  float: left;
+}
+
+.box {
+  width: 26px;
+  height: 13px;
+  margin-right: 5px;
+  clear: left;
+}
+
+.input .box {
+  background-color: #ffba49;
+}
+
+.output .box {
+  background-color: #20a39e;
+}

--- a/src/app/core/services/google-charts.service.ts
+++ b/src/app/core/services/google-charts.service.ts
@@ -1,0 +1,25 @@
+import { Injectable } from '@angular/core';
+import { Observable } from 'rxjs/Observable';
+import { Observer } from 'rxjs/Observer';
+import { ReplaySubject } from 'rxjs/ReplaySubject';
+
+@Injectable()
+export class GoogleCharts {
+  private version = 'current';
+  private packages = ['corechart'];
+  private loaded$ = new ReplaySubject<boolean>(1);
+
+  constructor() {
+    this.loaded$ = Observable.create((obs: Observer<boolean>) => {
+      (<any>window).google.charts.load(this.version, {packages: this.packages});
+      (<any>window).google.charts.setOnLoadCallback(() => {
+        obs.next(true);
+        obs.complete();
+      });
+    });
+  }
+
+  loaded(): Observable<boolean> {
+    return this.loaded$;
+  }
+}

--- a/src/app/core/services/mist-api.service.ts
+++ b/src/app/core/services/mist-api.service.ts
@@ -2,11 +2,29 @@ import { Injectable } from '@angular/core';
 import { Http } from '@angular/http';
 import { fieldMap as FieldMap } from '../common/fields';
 import { Entities } from '../common/entities';
+import { Observable } from 'rxjs/Observable';
+
+export enum SignalDomainKind {
+  Chemotaxis = 'chemotaxis',
+  Transmitter = 'transmitter',
+  Receiver = 'receiver',
+  Input = 'input',
+  Output = 'output',
+  ECF = 'ecf',
+  Unknown = 'unknown',
+}
+
+export interface SignalProfileCount {
+  kind: SignalDomainKind;
+  function: string;
+  numDomains: number;
+}
 
 @Injectable()
 export class MistApi {
   // static BASE_URL = 'https://api.mistdb.com/v1';
   static BASE_URL = 'http://localhost:5000/v1';
+  // static BASE_URL = 'https://api.mistdb.caltech.edu/v1';
   static GENOMES_ROOT = '/genomes';
   static GENES_ROOT = '/genes';
   static paginationParams = "page=%pageNumber%&per_page=%perPage%";
@@ -26,7 +44,7 @@ export class MistApi {
 
   processGenomesFilter(query: any, url: string): string {
     for (let option in query.filter) {
-      if ((query.filter.taxonmoyToRank.has(option) || option == "assembly_level") && query.filter[option]) { 
+      if ((query.filter.taxonmoyToRank.has(option) || option == "assembly_level") && query.filter[option]) {
         let optionReady = option === "clazz" ? "class" : option;
         url = `${url}&where.${optionReady}=${query.filter[option].trim()}`;
       }
@@ -86,5 +104,11 @@ export class MistApi {
 
   getBaseUrl(entity: string) {
     return MistApi.ENTITY_TO_BASEURL.get(entity);
+  }
+
+  fetchStProfileData(genomeVersion): Observable<SignalProfileCount[]> {
+    const url = this.getBaseUrl(Entities.GENOME) + `/${genomeVersion}/st-profile`;
+    return this.http.get(url)
+      .map((response) => <SignalProfileCount[]>response.json());
   }
 }

--- a/src/app/genome/genome.pug
+++ b/src/app/genome/genome.pug
@@ -2,3 +2,7 @@ mist-genome-view(
     [entity$]="genome$"
     [genomeViewModel]="genomeViewModel"
 )
+
+mist-st-profile(
+    [genomeVersion]="assemblyVersion"
+)

--- a/src/index.html
+++ b/src/index.html
@@ -13,5 +13,6 @@
 </head>
 <body>
   <app-root></app-root>
+  <script src="https://www.gstatic.com/charts/loader.js"></script>
 </body>
 </html>


### PR DESCRIPTION
The signal transduction profile graph quickly reveals the overall signal transduction capabilities for a given genome. This PR adds a component and supporting infrastructure for fetching the relevant data from the database and rendering a graph using google charts.

Also explicitly defined the `@ngtools/webpack` version necessary for successful compilation.

#### Screenshots
![st-profile](https://user-images.githubusercontent.com/19961495/46124450-4e9da200-c1f2-11e8-90f5-1a2ce34f29b6.gif)

