### PR TITLE
Signal transduction profile links and improved look and feel

### DIFF
--- a/src/app/app.component.pug
+++ b/src/app/app.component.pug
@@ -1,29 +1,23 @@
 header
-  mat-toolbar
-    div.mist-logo
+  .row
+    .five.columns.mist-logo
       a(routerLink="/")
         img.mist-svg(src="assets/images/mist_logo_white_green.svg")
-    .non-decor-white
-      br
-      br
-      p Attention: MIST3.0 database is in alpha phase. Development is underway. 
-      span Click {{ " " }}
-        a(href="http://u.osu.edu/zhulinlab/services/") here
-        span  {{ " " }} for additional information.
+    .seven.columns.notice
+      p MiST3 is currently in alpha and under development.
+        br
+        a(href="http://u.osu.edu/zhulinlab/services/") More info
 
-      
 .content
   mc-breadcrumbs
   div.box
-    
-  mist-main-menu
 
+  mist-main-menu
 
   .main.full-width-container
     router-outlet
 
-
 footer
   img.footer-logos(src="assets/images/NIH-min.png")
-  a.footer-style(href="http://u.osu.edu/zhulinlab/") {{ "Zhulin Lab" }}
+  a.footer-style(href="http://u.osu.edu/zhulinlab/") Zhulin Lab
   img.footer-style.footer-logos(src="assets/images/OSU.png")

--- a/src/app/app.component.pug
+++ b/src/app/app.component.pug
@@ -7,6 +7,8 @@ header
       p MiST3 is currently in alpha and under development.
         br
         a(href="http://u.osu.edu/zhulinlab/services/") More info
+        br
+        span(style="font-size: 14px") Feedback&Bug report: gumerov.1@osu.edu
 
 .content
   mc-breadcrumbs

--- a/src/app/app.component.scss
+++ b/src/app/app.component.scss
@@ -7,9 +7,42 @@ h1 {
   color: #495EB5;
 }
 
-mat-toolbar {
+header {
   background-color: #197477;
+
+  .notice {
+    padding: 1em;
+    text-align: center;
+    color: white;
+    font-size: 1.25em;
+  }
+
+  .row {
+    margin: 0;
+  }
+}
+
+.mist-logo {
+  text-align: center;
+}
+
+.mist-svg {
+  width: 250px;
   height: 140px;
+}
+
+@media screen and (min-width: 550px) {
+  header {
+    height: 140px;
+  }
+
+  header .notice {
+    text-align: right;
+  }
+
+  .mist-logo {
+    text-align: left;
+  }
 }
 
 footer {
@@ -18,14 +51,6 @@ footer {
   display: flex;
   align-items: center;
   justify-content: center;
-}
-
-.mist-logo {
-  margin-top: 80px;
-}
-.mist-svg {
-  width: 250px;
-  height: 140px;
 }
 
 .content {
@@ -49,11 +74,4 @@ footer {
   font-size: 24px;
   text-decoration: none;
   margin-left: 8%;
-}
-
-.non-decor-white {
-  margin-left: 20%;
-  color: white;
-  text-decoration: none;
-  text-align: center;
 }

--- a/src/app/core/services/mist-api.service.ts
+++ b/src/app/core/services/mist-api.service.ts
@@ -152,10 +152,11 @@ export class MistApi {
   }
 
   processSignalGenesFilter(query: any, url: string): string {
-    let ranks = query.filter.ranks ? `&where.ranks=${query.filter.ranks}` : "";
-    let componentId = query.filter.componentId ? `&where.component_id=${query.filter.componentId}` : ""
-    url = `${url}${ranks}${componentId}`;
-    return url;
+    const ranks = query.filter.ranks ? `&where.ranks=${query.filter.ranks}` : '';
+    const componentId = query.filter.componentId ? `&where.component_id=${query.filter.componentId}` : '';
+    const kind = query.filter.kind ? `&kind=${query.filter.kind}` : '';
+    const func = query.filter.stFunction ? `&function=${query.filter.stFunction}` : '';
+    return url + ranks + componentId + kind + func;
   }
 
   getByIdList(query: any, entity: string): string {

--- a/src/app/genome/genome.scss
+++ b/src/app/genome/genome.scss
@@ -1,6 +1,6 @@
 h3 {
   padding: 0 1em;
-  background-color: #125cd2;
+  background-color: #889999;
   color: #fff;
   font-size: 24px;
   margin: 0;

--- a/src/app/genome/signal_genes/signal_genes.component.ts
+++ b/src/app/genome/signal_genes/signal_genes.component.ts
@@ -9,7 +9,7 @@ import * as fromSignalGenes from './signal_genes.selectors';
 import { Filter } from '../../core/common/navigation';
 
 export default class SignalGenesFilter implements Filter {
-  constructor(public ranks, public componentId) {}
+  constructor(public ranks, public componentId, public kind, public stFunction) {}
   reset() {}
 }
 
@@ -34,11 +34,16 @@ export class SignalGenesComponent extends MistComponent {
       scope: null,
       perPage: this.perPage,
       pageIndex: this.defaultCurrentPage,
-      filter: this.initialyzeFilter()
+      filter: this.initialyzeFilter(),
     }));
   }
 
   initialyzeFilter(): Filter {
-    return new SignalGenesFilter(this.queryParams.ranks, this.queryParams.componentId);
+    return new SignalGenesFilter(
+      this.queryParams.ranks,
+      this.queryParams.componentId,
+      this.queryParams.kind,
+      this.queryParams.function,
+    );
   }
 }

--- a/src/app/home/home.component.pug
+++ b/src/app/home/home.component.pug
@@ -3,12 +3,12 @@ hr
 .row
   .four.columns
     h4 Introduction
-    p The MiST database was born in 2010 as to both predict and document bacterial signal transduction and provide a convenient portal for scientists to explore this knowledge. Unfortunately, this past year, the hardware powering MiST2 borked and our only backup unintentionally deleted.
+    p The MiST database was born in 2010 as to both predict and document signal transduction in bacteria and archaea and provide a convenient portal for scientists to explore this knowledge.
     p We have completely rewritten the MiST database from the ground up. The backend pipeline and database is virtually complete and accessible via its REST API, which powers this website. The frontend still has much work to be done. Please be patient as we continue its development.
 
   .four.columns
     h4 Statistics
-    ul
+    ul(style="list-style-type: none")
       li
         strong 125,000+
         |  genomes
@@ -21,8 +21,8 @@ hr
       li
         strong 100 million
         |  unique protein sequences
-    p The full domain architectures for 20,000 genomes is currently complete and we are continuously processing both existing and new genomes.
+    p Prediction of full domain architectures for 20,000 genomes is currently complete and we are continuously processing both existing and newly deposited genomes.
 
   .four.columns
     h4 Citation
-    p Manuscript is in preparation and will be published in the upcoming NAR database database series.
+    p Manuscript describing MiST3.0 is in preparation.

--- a/src/app/home/home.component.pug
+++ b/src/app/home/home.component.pug
@@ -1,22 +1,28 @@
-.container.nofull-width-container
-  .row
-    hr
+hr
 
-  .row
-    mat-grid-list(cols="3" rowHeight="3:4")
-      mat-grid-tile
-        ul.home-info
-          li
-            h4 Introduction
-      mat-grid-tile
-        ul.home-info
-          li
-            h4 Statistics
-          li > 132 000 genomes
-          li > 480 000 000 genes 
-          li > 80 000 000 precomputed features 
-      mat-grid-tile
-        ul.home-info
-          li
-            h4 Citation
-          li Manuscript describing MiST3.0 is in preparation. 
+.row
+  .four.columns
+    h4 Introduction
+    p The MiST database was born in 2010 as to both predict and document bacterial signal transduction and provide a convenient portal for scientists to explore this knowledge. Unfortunately, this past year, the hardware powering MiST2 borked and our only backup unintentionally deleted.
+    p We have completely rewritten the MiST database from the ground up. The backend pipeline and database is virtually complete and accessible via its REST API, which powers this website. The frontend still has much work to be done. Please be patient as we continue its development.
+
+  .four.columns
+    h4 Statistics
+    ul
+      li
+        strong 125,000+
+        |  genomes
+      li
+        strong 13 million
+        |  replicons / contigs
+      li
+        strong 516 million
+        |  genes
+      li
+        strong 100 million
+        |  unique protein sequences
+    p The full domain architectures for 20,000 genomes is currently complete and we are continuously processing both existing and new genomes.
+
+  .four.columns
+    h4 Citation
+    p Manuscript is in preparation and will be published in the upcoming NAR database database series.

--- a/src/app/home/home.scss
+++ b/src/app/home/home.scss
@@ -1,20 +1,3 @@
-mat-grid-tile {
-    background: #3dbfc1;
-}
-
-.right-side {
-    display: flex;
-    justify-content: flex-end;
-}
-
-.nofull-width-container { 
-    max-width: 960px;
-    clear: both;
-    margin: 0 auto;
-}
-
-.home-info {
-    list-style-type: none;
-    font-size: 18px;
-    margin: 5%;
+.row {
+    margin: 0 2em;
 }

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -203,7 +203,7 @@ mat-checkbox.mat-checked ._mat-icon {
 // Distribution table
 .distribution-table {
     h4 {
-        color: #ae6500;
+        color: #197477;
         margin: .5em 1em;
         font-size: 24px;
     }


### PR DESCRIPTION
Clicking on the signal transduction profile graph now shows those genes for each category:
![linked-st-profile](https://user-images.githubusercontent.com/19961495/46449600-df2c3300-c75a-11e8-9612-0b32704414f3.gif)

Added some text to the home page and made it more responsive:
![screen shot 2018-10-03 at 10 20 40 pm](https://user-images.githubusercontent.com/19961495/46449611-ee12e580-c75a-11e8-919d-255d4d406d5d.png)

![screen shot 2018-10-03 at 10 20 51 pm](https://user-images.githubusercontent.com/19961495/46449613-f10dd600-c75a-11e8-96f0-590e5fce5e4a.png)

![screen shot 2018-10-03 at 10 20 56 pm](https://user-images.githubusercontent.com/19961495/46449614-f3703000-c75a-11e8-91c5-6de799ca4c2a.png)

