### PR TITLE
Show chemotaxis total if no subtypes (e.g. CheW)

### DIFF
--- a/src/app/core/components/chemotaxis-count-links/chemotaxis-count-links.component.ts
+++ b/src/app/core/components/chemotaxis-count-links/chemotaxis-count-links.component.ts
@@ -1,4 +1,5 @@
-import { ChangeDetectionStrategy, Component, Input } from '@angular/core';
+import { ChangeDetectionStrategy, Component, Input, OnInit } from '@angular/core';
+
 import { PrimaryRank, SecondaryRank } from '../../common/stp-utils';
 
 @Component({
@@ -7,21 +8,32 @@ import { PrimaryRank, SecondaryRank } from '../../common/stp-utils';
   styleUrls: ['./chemotaxis-count-links.scss'],
   templateUrl: './chemotaxis-count-links.pug',
 })
-export class ChemotaxisCountLinksComponent {
+export class ChemotaxisCountLinksComponent implements OnInit {
   @Input() counts: any;
   @Input() secondaryRank: SecondaryRank;
   @Input() componentId: number;
 
+  hasSubTypes = true;
+
+  ngOnInit() {
+    this.hasSubTypes = this.counts && this.counts[this.secondaryRank] && Object.keys(this.counts[this.secondaryRank]).length > 1;
+  }
+
   queryParams(secondaryRank: string, type: string) {
     const { componentId } = this;
-    // for some reason 24H,28H and MAC2 need differently ordered query parameters
-    let ranks = type === '24H' || type === '28H' || type === 'MAC2' 
-      ? `${type},${PrimaryRank.chemotaxis},${secondaryRank}`
-      : `${PrimaryRank.chemotaxis},${secondaryRank},${type}`;
+    let ranks = `${PrimaryRank.chemotaxis},${secondaryRank}`;
+    if (type) {
+      // for some reason 24H,28H and MAC2 need differently ordered query parameters
+      if (type === '24H' || type === '28H' || type === 'MAC2') {
+        ranks = `${type},${ranks}`;
+      } else {
+        ranks = `${ranks},${type}`;
+      }
+    }
 
     return {
       ...(componentId && {componentId}),
-      ranks: ranks,
+      ranks,
     };
   }
 }

--- a/src/app/core/components/chemotaxis-count-links/chemotaxis-count-links.pug
+++ b/src/app/core/components/chemotaxis-count-links/chemotaxis-count-links.pug
@@ -6,3 +6,12 @@ ng-container(*ngIf="counts && counts[secondaryRank]?.$total > 0")
   )
     span.type {{ type }}&nbsp;
     span.count {{ counts[secondaryRank][type].$total }}
+
+  //- Special case for those chemotaxis proteins that don't have subtypes
+  //- (e.g. CheW)
+  a(
+    *ngIf="!hasSubTypes"
+    routerLink="signal-genes"
+    [queryParams]="queryParams(secondaryRank)"
+  )
+    span.count {{ counts[secondaryRank].$total }}


### PR DESCRIPTION
### Work done
On the genome page, the chemotaxis count for CheW was not shown :| This PR fixes that.

#### Tests
- [ ] Open genome pages for bugs known to have a CheW. Confirm there is a CheW value in the chemotaxis table that when clicked shows those CheWs.

### Screenshots
#### Before
<img width="289" alt="Screen Shot 2020-03-03 at 6 18 24 PM" src="https://user-images.githubusercontent.com/19961495/75829197-8dd30980-5d7b-11ea-8aaa-68b368d3a660.png">

#### After
<img width="407" alt="Screen Shot 2020-03-03 at 6 19 08 PM" src="https://user-images.githubusercontent.com/19961495/75829201-91669080-5d7b-11ea-86a2-1ad8095b0ce4.png">
